### PR TITLE
[#3] Feature for configure where to pin

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,6 @@
 import { App, Plugin, TFile, WorkspaceLeaf, View } from 'obsidian';
+import { PinDailyNotePluginSetting as Setting, PinDailyNotePluginSettingTab as SettingTab, DEFAULT_SETTING } from 'setting';
+
 
 interface DailyNotesSettings {
     folder?: string;
@@ -31,8 +33,10 @@ interface ObsidianView extends View {
     file?: TFile;
 }
 
+
 export default class PinDailyNotePlugin extends Plugin {
     private obsidianApp: ObsidianApp;
+    settings: Setting; // non private for access from Setting class
 
     constructor(app: App, manifest: any) {
         super(app, manifest);
@@ -99,6 +103,17 @@ export default class PinDailyNotePlugin extends Plugin {
             name: 'Open today\'s daily note',
             callback: () => handleDailyNote(),
         });
+
+        await this.loadSettings()
+        this.addSettingTab(new SettingTab(this.app, this))
+    }
+
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTING, await this.loadData())
+    }
+
+    async saveSettings() {
+        this.saveData(this.settings)
     }
 
     getTodayNotePath(): string | null {
@@ -112,7 +127,7 @@ export default class PinDailyNotePlugin extends Plugin {
             const folder = settings.folder?.trim().replace(/\/$/, '') || '';
             const format = settings.format?.trim() || 'YYYY-MM-DD';
             const date = window.moment();
-            
+
             let filename = date.format(format);
             if (format.includes('/')) {
                 const formattedPath = folder
@@ -133,7 +148,7 @@ export default class PinDailyNotePlugin extends Plugin {
 
     isDailyNotePath(path: string | undefined): boolean {
         if (!path) return false;
-        
+
         const dailyNotesPlugin = this.obsidianApp.internalPlugins.plugins['daily-notes'];
         if (!dailyNotesPlugin?.enabled) return false;
 
@@ -142,7 +157,7 @@ export default class PinDailyNotePlugin extends Plugin {
             if (!settings) return false;
 
             const folder = settings.folder?.trim().replace(/\/$/, '') || '';
-            
+
             if (folder && !path.startsWith(folder)) return false;
 
             const filename = path.slice(folder ? folder.length + 1 : 0, -3);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-pinned-daily-notes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-pinned-daily-notes",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.11.6",

--- a/setting.ts
+++ b/setting.ts
@@ -1,0 +1,48 @@
+import PinDailyNotePlugin from "./main"
+import { App, DropdownComponent, PluginSettingTab, Setting } from "obsidian"
+
+export interface PinDailyNotePluginSetting {
+    whereToPin: string
+}
+
+export enum PinOptions {
+    EDITOR = 'editor',
+    LEFT_SIDE_BAR = 'leftSideBar',
+    rightSideBar = 'rightSideBar',
+}
+
+export const DEFAULT_SETTING: Partial<PinDailyNotePluginSetting> = {
+    whereToPin: PinOptions.EDITOR
+}
+
+export class PinDailyNotePluginSettingTab extends PluginSettingTab {
+    plugin: PinDailyNotePlugin
+
+    constructor(app: App, plugin: PinDailyNotePlugin) {
+        super(app, plugin)
+        this.plugin = plugin;
+    }
+
+    display(): void {
+        const { containerEl } = this;
+        containerEl.empty()
+
+        new Setting(containerEl)
+            .setName('Where to Pin')
+            .setDesc('Default place to pin Daily Note')
+            .addDropdown((dropdown) => {
+                dropdown.addOptions(whereToPinDropdownOptions)
+                dropdown.setValue(this.plugin.settings.whereToPin)
+                dropdown.onChange(async (value) => {
+                    this.plugin.settings.whereToPin = value;
+                    await this.plugin.saveSettings()
+                })
+            })
+    }
+}
+
+const whereToPinDropdownOptions: Record<string, PinOptions> = {
+    editor: PinOptions.EDITOR,
+    leftSideBar: PinOptions.LEFT_SIDE_BAR,
+    rightSideBar: PinOptions.rightSideBar
+}

--- a/setting.ts
+++ b/setting.ts
@@ -8,7 +8,7 @@ export interface PinDailyNotePluginSetting {
 export enum PinOptions {
     EDITOR = 'editor',
     LEFT_SIDE_BAR = 'leftSideBar',
-    rightSideBar = 'rightSideBar',
+    RIGHT_SIDE_BAR = 'rightSideBar',
 }
 
 export const DEFAULT_SETTING: Partial<PinDailyNotePluginSetting> = {
@@ -44,5 +44,5 @@ export class PinDailyNotePluginSettingTab extends PluginSettingTab {
 const whereToPinDropdownOptions: Record<string, PinOptions> = {
     editor: PinOptions.EDITOR,
     leftSideBar: PinOptions.LEFT_SIDE_BAR,
-    rightSideBar: PinOptions.rightSideBar
+    rightSideBar: PinOptions.RIGHT_SIDE_BAR
 }


### PR DESCRIPTION
### Features
1. Setting UI with dropdown for where to pin options [ Editor as default, Left side bar, Right side bar ]
2. Pin today's daily note based on pin place configuration

### Limits
1. when today's daily note is not exist, the "where to pin" option is not applicable
    - Because of the usage of 'Daily Note' plugins command for this case, despite of the configuration, today's daily note is created and open on editor leaf.
    - I left this limitation to discuss about with maintainer. Personally, this limitation is not critical to my daily workflow with obsidian.
   